### PR TITLE
feat(script-manager): (Extension) Created theme switching

### DIFF
--- a/Extension/Script-manager.js
+++ b/Extension/Script-manager.js
@@ -10,9 +10,9 @@
 // ==/UserScript==
 
 ; (async () => {
-  console.log('%c🚀 WPlace AutoBOT Script Manager Loading...', 'color: #00ff41; font-weight: bold; font-size: 16px;');
+  console.log('%c🚀 WPlace AutoBOT Script Manager Loading...', 'color: var(--wplace-text, #4facfe); font-weight: bold; font-size: 16px;');
 
-  // Available scripts configuration
+  
   const AVAILABLE_SCRIPTS = [
     { 
       name: 'Auto-Farm.js', 
@@ -37,29 +37,46 @@
     }
   ];
 
-  // Neon theme styling
+  
   const NEON_STYLES = `
     @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+    
+    :root, .wplace-theme-neon, .wplace-theme-classic, .wplace-theme-classic-light, .wplace-theme-acrylic {
+      --sm-primary: var(--wplace-primary, #1a1a2e);
+      --sm-secondary: var(--wplace-secondary, #16213e);
+      --sm-accent: var(--wplace-accent, #0f3460);
+      --sm-text: var(--wplace-text, #00ff41);
+      --sm-highlight: var(--wplace-highlight, #ff6b35);
+      --sm-success: var(--wplace-success, #39ff14);
+      --sm-error: var(--wplace-error, #ff073a);
+      --sm-warning: var(--wplace-warning, #ff0);
+      --sm-font: var(--wplace-font, 'Press Start 2P', monospace, 'Courier New');
+      --sm-border-color: var(--wplace-text, #00ff41);
+      --sm-border-width: 3px;
+      --sm-shadow-glow-a: 0 0 30px rgb(0 255 65 / 50%);
+      --sm-shadow-glow-b: inset 0 0 30px rgb(0 255 65 / 10%);
+      --sm-shadow-outline: 0 0 0 1px var(--sm-border-color);
+    }
     
     .script-manager-container {
       position: fixed !important;
       top: 50% !important;
       left: 50% !important;
       transform: translate(-50%, -50%) !important;
-      background: #1a1a2e;
-      border: 3px solid #00ff41;
+      background: var(--sm-primary);
+      border: var(--sm-border-width) solid var(--sm-border-color);
       border-radius: 0;
       box-shadow: 
-        0 0 30px rgb(0 255 65 / 50%), 
-        inset 0 0 30px rgb(0 255 65 / 10%),
-        0 0 0 1px #00ff41;
-      font-family: 'Press Start 2P', monospace, 'Courier New';
+        var(--sm-shadow-glow-a), 
+        var(--sm-shadow-glow-b),
+        var(--sm-shadow-outline);
+      font-family: var(--sm-font);
       z-index: 10001 !important;
       min-width: 600px;
       max-width: 800px;
       max-height: 80vh;
       overflow: hidden;
-      color: #00ff41;
+      color: var(--sm-text);
       animation: neon-pulse 2s ease-in-out infinite alternate;
     }
     
@@ -70,7 +87,7 @@
       left: 0;
       right: 0;
       height: 2px;
-      background: linear-gradient(90deg, transparent, #00ff41, transparent);
+  background: linear-gradient(90deg, transparent, var(--sm-text), transparent);
       z-index: 1;
       pointer-events: none;
       animation: scanline 3s linear infinite;
@@ -78,8 +95,8 @@
     }
     
     .script-manager-header {
-      background: #16213e;
-      border-bottom: 2px solid #00ff41;
+      background: var(--sm-secondary);
+      border-bottom: 2px solid var(--sm-border-color);
       padding: 15px 20px;
       position: relative;
       display: flex;
@@ -108,9 +125,9 @@
     }
     
     .script-manager-title {
-      color: #00ff41;
+      color: var(--sm-text);
       font-size: 14px;
-      text-shadow: 0 0 15px #00ff41;
+      text-shadow: 0 0 15px var(--sm-text);
       margin: 0;
       text-transform: uppercase;
       letter-spacing: 2px;
@@ -118,10 +135,10 @@
     }
     
     .script-manager-close {
-      background: #16213e;
-      border: 2px solid #ff073a;
+      background: var(--sm-secondary);
+      border: 2px solid var(--sm-error);
       border-radius: 0;
-      color: #ff073a;
+      color: var(--sm-error);
       width: 30px;
       height: 30px;
       cursor: pointer;
@@ -131,13 +148,13 @@
       align-items: center;
       justify-content: center;
       transition: all 0.3s ease;
-      text-shadow: 0 0 10px #ff073a;
+  text-shadow: 0 0 10px var(--sm-error);
     }
     
     .script-manager-close:hover {
-      background: #ff073a;
-      color: #1a1a2e;
-      box-shadow: 0 0 20px #ff073a;
+      background: var(--sm-error);
+      color: var(--sm-primary);
+      box-shadow: 0 0 20px var(--sm-error);
       animation: pixel-blink 0.5s infinite;
     }
     
@@ -145,7 +162,7 @@
       padding: 20px;
       max-height: 60vh;
       overflow-y: auto;
-      background: linear-gradient(45deg, rgba(0,255,65,0.03) 0%, rgba(22,33,62,0.05) 100%);
+      background: linear-gradient(45deg, rgba(255,255,255,0.04) 0%, rgba(0,0,0,0.15) 100%);
     }
     
     .script-grid {
@@ -156,8 +173,8 @@
     }
     
     .script-card {
-      background: #16213e;
-      border: 2px solid #00ff41;
+      background: var(--sm-secondary);
+      border: 2px solid var(--sm-border-color);
       border-radius: 0;
       padding: 15px;
       cursor: pointer;
@@ -184,10 +201,10 @@
     }
     
     .script-card:hover {
-      background: rgba(0,255,65,0.1);
+      background: rgba(255,255,255,0.08);
       box-shadow: 
-        0 0 25px rgb(0 255 65 / 60%),
-        inset 0 0 25px rgb(0 255 65 / 15%);
+        0 0 25px var(--sm-text),
+        inset 0 0 25px rgb(255 255 255 / 10%);
       transform: translateY(-3px);
       animation: card-glow 0.5s ease-in-out infinite alternate;
     }
@@ -201,41 +218,41 @@
     .script-icon {
       font-size: 24px;
       margin-right: 10px;
-      filter: drop-shadow(0 0 10px #00ff41);
+      filter: drop-shadow(0 0 10px var(--sm-text));
     }
     
     .script-title {
-      color: #00ff41;
+      color: var(--sm-text);
       font-size: 11px;
-      text-shadow: 0 0 10px #00ff41;
+      text-shadow: 0 0 10px var(--sm-text);
       text-transform: uppercase;
       letter-spacing: 1px;
       margin: 0;
     }
     
     .script-description {
-      color: #00ff41dd;
+      color: var(--sm-text);
       font-size: 8px;
       line-height: 1.4;
-      text-shadow: 0 0 5px #00ff41;
+      text-shadow: 0 0 5px var(--sm-text);
       margin-bottom: 15px;
     }
     
     .script-category {
       background: rgba(255, 107, 53, 0.2);
-      border: 1px solid #ff6b35;
-      color: #ff6b35;
+      border: 1px solid var(--sm-highlight);
+      color: var(--sm-highlight);
       padding: 3px 8px;
       font-size: 7px;
       text-transform: uppercase;
       letter-spacing: 1px;
-      text-shadow: 0 0 5px #ff6b35;
+      text-shadow: 0 0 5px var(--sm-highlight);
       display: inline-block;
     }
     
     .script-manager-footer {
-      background: #16213e;
-      border-top: 2px solid #00ff41;
+      background: var(--sm-secondary);
+      border-top: 2px solid var(--sm-border-color);
       padding: 15px 20px;
       display: flex;
       justify-content: space-between;
@@ -243,9 +260,9 @@
     }
     
     .status-text {
-      color: #00ff41dd;
+      color: var(--sm-text);
       font-size: 8px;
-      text-shadow: 0 0 5px #00ff41;
+      text-shadow: 0 0 5px var(--sm-text);
     }
     
     .action-buttons {
@@ -254,35 +271,70 @@
     }
     
     .neon-btn {
-      background: #16213e;
-      border: 2px solid #00ff41;
+      background: var(--sm-secondary);
+      border: 2px solid var(--sm-border-color);
       border-radius: 0;
-      color: #00ff41;
+      color: var(--sm-text);
       padding: 8px 15px;
       font-family: 'Press Start 2P', monospace;
       font-size: 8px;
       text-transform: uppercase;
       cursor: pointer;
       transition: all 0.3s ease;
-      text-shadow: 0 0 8px #00ff41;
+      text-shadow: 0 0 8px var(--sm-text);
       letter-spacing: 1px;
     }
     
     .neon-btn:hover {
-      background: rgba(0,255,65,0.1);
-      box-shadow: 0 0 20px rgb(0 255 65 / 60%);
+      background: rgba(255,255,255,0.1);
+      box-shadow: 0 0 20px var(--sm-text);
       animation: pixel-blink 0.5s infinite;
     }
     
     .neon-btn.secondary {
-      border-color: #ff6b35;
-      color: #ff6b35;
-      text-shadow: 0 0 8px #ff6b35;
+      border-color: var(--sm-highlight);
+      color: var(--sm-highlight);
+      text-shadow: 0 0 8px var(--sm-highlight);
     }
     
     .neon-btn.secondary:hover {
       background: rgba(255, 107, 53, 0.1);
-      box-shadow: 0 0 20px rgb(255 107 53 / 60%);
+      box-shadow: 0 0 20px var(--sm-highlight);
+    }
+
+    /* Theme select styling */
+    #autobot-theme-select.neon-select {
+      appearance: none;
+      -webkit-appearance: none;
+      background: var(--sm-secondary);
+      color: var(--sm-text);
+      border: 2px solid var(--sm-border-color);
+      text-shadow: 0 0 6px color-mix(in srgb, var(--sm-text) 40%, transparent);
+      padding: 6px 28px 6px 10px !important;
+      position: relative;
+      cursor: pointer;
+      line-height: 1.2;
+      letter-spacing: 0.5px;
+      font-size: 10px;
+      background-image: linear-gradient(45deg, transparent 50%, var(--sm-text) 50%), linear-gradient(135deg, var(--sm-text) 50%, transparent 50%);
+      background-position: right 10px top 55%, right 4px top 55%;
+      background-size: 8px 8px, 8px 8px;
+      background-repeat: no-repeat;
+    }
+
+    #autobot-theme-select.neon-select:hover {
+      box-shadow: 0 0 14px color-mix(in srgb, var(--sm-text) 55%, transparent);
+    }
+
+    #autobot-theme-select.neon-select:focus {
+      outline: 2px solid var(--sm-highlight);
+      outline-offset: 1px;
+      box-shadow: 0 0 0 2px var(--sm-highlight), 0 0 18px color-mix(in srgb, var(--sm-highlight) 60%, transparent);
+    }
+
+    #autobot-theme-select.neon-select option {
+      background: var(--sm-primary);
+      color: var(--sm-text);
     }
     
     .script-manager-backdrop {
@@ -297,7 +349,7 @@
       animation: backdrop-fade-in 0.3s ease-out;
     }
     
-    /* Loading animation */
+    
     .loading-container {
       display: flex;
       flex-direction: column;
@@ -310,7 +362,7 @@
       width: 40px;
       height: 40px;
       border: 3px solid #16213e;
-      border-top: 3px solid #00ff41;
+  border-top: 3px solid var(--sm-border-color);
       border-radius: 0;
       animation: neon-spin 1s linear infinite;
       margin-bottom: 15px;
@@ -318,44 +370,44 @@
     }
     
     .loading-text {
-      color: #00ff41;
+  color: var(--sm-text);
       font-size: 8px;
-      text-shadow: 0 0 10px #00ff41;
+  text-shadow: 0 0 10px var(--sm-text);
       text-transform: uppercase;
       letter-spacing: 2px;
       animation: text-pulse 1.5s ease-in-out infinite;
     }
     
-    /* Custom scrollbar */
+    
     .script-manager-content::-webkit-scrollbar {
       width: 12px;
     }
     
     .script-manager-content::-webkit-scrollbar-track {
       background: #16213e;
-      border: 1px solid #00ff41;
+  border: 1px solid var(--sm-border-color);
     }
     
     .script-manager-content::-webkit-scrollbar-thumb {
-      background: #00ff41;
+  background: var(--sm-text);
       border-radius: 0;
-      box-shadow: 0 0 10px #00ff41;
+  box-shadow: 0 0 10px var(--sm-text);
     }
     
     .script-manager-content::-webkit-scrollbar-thumb:hover {
-      background: #39ff14;
-      box-shadow: 0 0 15px #39ff14;
+  background: var(--sm-success);
+  box-shadow: 0 0 15px var(--sm-success);
     }
     
-    /* Animations */
+    
     @keyframes neon-pulse {
-      0% { box-shadow: 0 0 30px rgb(0 255 65 / 50%), inset 0 0 30px rgb(0 255 65 / 10%), 0 0 0 1px #00ff41; }
-      100% { box-shadow: 0 0 40px rgb(0 255 65 / 70%), inset 0 0 40px rgb(0 255 65 / 15%), 0 0 0 1px #00ff41; }
+  0% { box-shadow: var(--sm-shadow-glow-a), var(--sm-shadow-glow-b), var(--sm-shadow-outline); }
+  100% { box-shadow: 0 0 40px color-mix(in srgb, var(--sm-text) 70%, transparent), inset 0 0 40px color-mix(in srgb, var(--sm-text) 15%, transparent), var(--sm-shadow-outline); }
     }
     
     @keyframes text-glow {
-      0% { text-shadow: 0 0 15px #00ff41; }
-      100% { text-shadow: 0 0 25px #00ff41, 0 0 35px #00ff41; }
+  0% { text-shadow: 0 0 15px var(--sm-text); }
+  100% { text-shadow: 0 0 25px var(--sm-text), 0 0 35px var(--sm-text); }
     }
     
     @keyframes pixel-blink {
@@ -394,7 +446,7 @@
       100% { opacity: 1; }
     }
     
-    /* Responsive design */
+    
     @media (max-width: 768px) {
       .script-manager-container {
         min-width: 90vw;
@@ -410,6 +462,124 @@
       }
     }
   `;
+
+  
+  function toTitleLabel(base) {
+    // Special cases
+    if (base === 'ph') return 'PH';
+    if (base === 'classic-light') return 'Classic Light';
+    // Convert kebab / snake to Title Case
+    return base.replace(/[-_]+/g, ' ') 
+               .replace(/\b\w/g, c => c.toUpperCase());
+  }
+
+  function discoverThemes() {
+    // Prefer manager-specific themes if provided
+    const managerObj = (window.AUTOBOT_MANAGER_THEMES || {});
+    const baseObj = (window.AUTOBOT_THEMES || {});
+
+    // Build a unified map giving precedence to manager variants
+    const combined = { ...baseObj };
+    // Manager themes override (or add new) by filename
+    Object.keys(managerObj).forEach(fn => { combined[fn] = managerObj[fn]; });
+
+    const files = Object.keys(combined)
+      .filter(f => f.endsWith('.css'))
+      .filter(f => f !== 'auto-image-styles.css');
+
+    const list = files.map(f => {
+      const base = f.replace(/\.css$/, '');
+      return {
+        value: base,
+        label: toTitleLabel(base),
+        className: 'wplace-theme-' + base
+      };
+    }).sort((a,b)=> a.label.localeCompare(b.label));
+
+    if (list.length === 0) {
+      return [ { value: 'neon', label: 'Neon Retro', className: 'wplace-theme-neon' } ];
+    }
+    return list;
+  }
+
+  let AVAILABLE_THEMES = discoverThemes();
+
+  
+  if (!AVAILABLE_THEMES || AVAILABLE_THEMES.length <= 1) {
+    setTimeout(() => { AVAILABLE_THEMES = discoverThemes(); }, 500);
+  }
+
+  const THEME_STORAGE_KEY = 'autobot-selected-theme';
+  let currentTheme = localStorage.getItem(THEME_STORAGE_KEY) || 'neon';
+
+  function logTheme(msg, color = '#8b5cf6') {
+    console.log(`%c🎨 ThemeSwitcher: ${msg}`,'color:'+color+';font-weight:bold;');
+  }
+
+  // Inject (or update) the manager-specific theme CSS layer so it overrides the base theme
+  function applyManagerThemeLayer(themeValue) {
+    try {
+      const mgr = (window.AUTOBOT_MANAGER_THEMES || {});
+      const fileName = themeValue + '.css';
+      const css = mgr[fileName];
+      const STYLE_ID = 'autobot-manager-theme';
+      // Always remove previous layer first so we don't accumulate
+      const prev = document.getElementById(STYLE_ID);
+      if (prev) prev.remove();
+      if (!css) {
+        logTheme(`No manager theme layer for '${themeValue}' (file ${fileName})`, '#ef4444');
+        return false;
+      }
+      const el = document.createElement('style');
+      el.id = STYLE_ID;
+      el.textContent = css;
+      document.head.appendChild(el);
+      logTheme(`Manager layer injected: ${fileName}`, '#10b981');
+      return true;
+    } catch (e) {
+      console.warn('Manager theme layer injection failed', e);
+      return false;
+    }
+  }
+
+  function applyAutobotTheme(themeValue) {
+    const found = AVAILABLE_THEMES.find(t => t.value === themeValue) || AVAILABLE_THEMES[0];
+    currentTheme = found.value;
+    localStorage.setItem(THEME_STORAGE_KEY, currentTheme);
+
+    
+    document.documentElement.classList.forEach(cls => {
+      if (cls.startsWith('wplace-theme-')) {
+        document.documentElement.classList.remove(cls);
+      }
+    });
+
+    
+    if (typeof window.applyTheme === 'function') {
+      const success = window.applyTheme(found.value);
+      if (!success) {
+        document.documentElement.classList.add(found.className);
+        logTheme(`Fallback class applied: ${found.className}`, '#f59e0b');
+      } else {
+        // Ensure matching class for variable-based selectors (some themes depend on it)
+        document.documentElement.classList.add(found.className);
+        logTheme(`Applied via window.applyTheme('${found.value}')`, '#10b981');
+      }
+    } else {
+      document.documentElement.classList.add(found.className);
+      logTheme(`applyTheme helper missing; class applied: ${found.className}`, '#f59e0b');
+    }
+
+    
+    const layered = applyManagerThemeLayer(found.value);
+    if (!layered) {
+      // If no manager CSS, we still rely on base theme + class selectors
+      logTheme(`Using base theme only for '${found.value}'`, '#3b82f6');
+    }
+  }
+
+  // Pre-apply the stored theme early
+  try { applyAutobotTheme(currentTheme); } catch(e){ console.warn('Theme pre-apply failed', e);}  
 
   // Execute script function - Fixed to work like extension popup
   async function executeScript(scriptName) {
@@ -591,10 +761,17 @@
         <!-- Scripts will be rendered here -->
       </div>
       <div class="script-manager-footer">
-        <div class="status-text">Ready to launch scripts</div>
-        <div class="action-buttons">
-          <button class="neon-btn secondary" onclick="closeScriptManager()">Cancel</button>
-          <button class="neon-btn" onclick="window.location.reload()">Refresh Page</button>
+        <div style="display:flex;align-items:center;gap:12px;width:100%;justify-content:space-between;">
+          <div class="status-text">Ready • Theme:</div>
+          <div class="theme-select-wrapper" style="display:flex;align-items:center;gap:6px;">
+            <select id="autobot-theme-select" class="neon-btn neon-select" style="padding:4px 8px;min-width:160px;">
+              ${AVAILABLE_THEMES.map(t => `<option value="${t.value}" ${t.value===currentTheme?'selected':''}>${t.label}</option>`).join('')}
+            </select>
+          </div>
+          <div class="action-buttons">
+            <button class="neon-btn secondary" onclick="closeScriptManager()">Cancel</button>
+            <button class="neon-btn" onclick="window.location.reload()">Refresh</button>
+          </div>
         </div>
       </div>
     `;
@@ -622,6 +799,15 @@
     container.focus();
     
     console.log('%c✅ Script Manager opened successfully', 'color: #39ff14; font-weight: bold;');
+
+    // Theme select listener (after render)
+    const themeSelect = container.querySelector('#autobot-theme-select');
+    if (themeSelect) {
+      themeSelect.addEventListener('change', (e) => {
+        const v = e.target.value;
+        applyAutobotTheme(v);
+      });
+    }
   }
 
   // Make functions globally available

--- a/Extension/Script-manager.js
+++ b/Extension/Script-manager.js
@@ -808,6 +808,9 @@
         applyAutobotTheme(v);
       });
     }
+
+  // Re-apply current theme so manager theme layer is injected AFTER neon fallback styles
+  try { applyAutobotTheme(currentTheme); } catch(e){ console.warn('Post-open theme reapply failed', e);}  
   }
 
   // Make functions globally available

--- a/Extension/script-manager-themes/acrylic.css
+++ b/Extension/script-manager-themes/acrylic.css
@@ -20,17 +20,64 @@
   --sm-scrollbar-track: rgba(255,255,255,0.05);
   --sm-scrollbar-thumb: rgba(255,255,255,0.25);
   --sm-scrollbar-thumb-hover: rgba(255,255,255,0.38);
+  /* Acrylic customization tokens */
+  --sm-acrylic-blur: 22px;
+  --sm-acrylic-saturation: 185%;
+  --sm-acrylic-opacity: 0.85; /* main frosted layer strength */
+  --sm-acrylic-noise-opacity: 0.035; /* noise grain intensity */
+  --sm-acrylic-border-alpha: 0.32;
+  --sm-acrylic-glow-color: rgba(125,211,252,0.55);
+  --sm-acrylic-gradient-angle: 135deg;
+  --sm-acrylic-tint-a: rgba(255,255,255,0.55);
+  --sm-acrylic-tint-b: rgba(255,255,255,0.07);
 }
 
 .wplace-theme-acrylic .script-manager-container {
-  background: var(--sm-primary) !important;
-  backdrop-filter: blur(18px) saturate(180%) !important;
-  border: var(--sm-border-width) solid var(--sm-border-color) !important;
-  box-shadow: var(--sm-shadow-glow-a), var(--sm-shadow-glow-b) !important;
+  background: linear-gradient(var(--sm-acrylic-gradient-angle), rgba(255,255,255,0.16), rgba(255,255,255,0.04)) border-box !important;
+  overflow: hidden !important;
+  border: 1px solid rgba(255,255,255,var(--sm-acrylic-border-alpha)) !important;
+  box-shadow: 0 4px 18px -4px rgba(0,0,0,0.45), 0 10px 40px -8px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.12), 0 0 0 1px var(--sm-accent) inset !important;
   color: var(--sm-text) !important;
   font-family: var(--sm-font) !important;
   border-radius: 18px !important;
 }
+
+/* Acrylic layered effects */
+.wplace-theme-acrylic .script-manager-container::before {
+  content: '';
+  position: absolute; inset: 0;
+  background:
+    linear-gradient(var(--sm-acrylic-gradient-angle), var(--sm-acrylic-tint-a), var(--sm-acrylic-tint-b))
+    , radial-gradient(circle at 20% 15%, rgba(255,255,255,0.35), transparent 65%)
+    , radial-gradient(circle at 80% 80%, rgba(125,211,252,0.35), transparent 70%);
+  mix-blend-mode: normal;
+  pointer-events: none;
+  backdrop-filter: blur(var(--sm-acrylic-blur)) saturate(var(--sm-acrylic-saturation));
+  -webkit-backdrop-filter: blur(var(--sm-acrylic-blur)) saturate(var(--sm-acrylic-saturation));
+  opacity: var(--sm-acrylic-opacity);
+  transition: opacity .4s ease;
+}
+
+.wplace-theme-acrylic .script-manager-container::after {
+  content: '';
+  position: absolute; inset: 0;
+  background:
+    repeating-linear-gradient(0deg, rgba(255,255,255,var(--sm-acrylic-noise-opacity)) 0 1px, transparent 1px 2px),
+    repeating-linear-gradient(90deg, rgba(255,255,255,var(--sm-acrylic-noise-opacity)) 0 1px, transparent 1px 2px);
+  mix-blend-mode: overlay;
+  pointer-events: none;
+  opacity: 1;
+  animation: sm-acrylic-noise 6s steps(3,end) infinite;
+}
+
+@keyframes sm-acrylic-noise {
+  0%,100% { transform: translate3d(0,0,0); }
+  33% { transform: translate3d(2px,-1px,0); }
+  66% { transform: translate3d(-1px,1px,0); }
+}
+
+.wplace-theme-acrylic .script-manager-container:hover::before { opacity: calc(var(--sm-acrylic-opacity) + 0.05); }
+.wplace-theme-acrylic .script-manager-container:focus-within::before { opacity: calc(var(--sm-acrylic-opacity) + 0.1); }
 
 .wplace-theme-acrylic .script-manager-header {
   background: linear-gradient(135deg, rgba(255,255,255,0.08), rgba(255,255,255,0.02)) !important;
@@ -47,7 +94,8 @@
 .wplace-theme-acrylic .script-manager-close-btn:hover { background: rgba(255,255,255,0.15) !important; }
 
 .wplace-theme-acrylic .theme-select-wrapper { background: rgba(255,255,255,0.08) !important; border:1px solid rgba(255,255,255,0.15) !important; }
-.wplace-theme-acrylic select.theme-select { background: rgba(0,0,0,0.35) !important; color: var(--sm-text) !important; border:1px solid rgba(255,255,255,0.2) !important; }
+.wplace-theme-acrylic select.theme-select { background: rgba(20,20,28,0.45) !important; backdrop-filter: blur(10px) saturate(160%) !important; color: #eaf6ff !important; border:1px solid rgba(255,255,255,0.35) !important; text-shadow: 0 1px 2px rgba(0,0,0,0.6); }
+.wplace-theme-acrylic select.theme-select option { background: rgba(15,15,22,0.85) !important; color:#eaf6ff !important; }
 
 .wplace-theme-acrylic .script-grid { scrollbar-color: var(--sm-scrollbar-thumb) var(--sm-scrollbar-track); }
 .wplace-theme-acrylic .script-card {
@@ -59,14 +107,23 @@
   position: relative;
   overflow: hidden;
 }
+.wplace-theme-acrylic .script-card::after {
+  content: '';
+  position: absolute; inset: 0;
+  background: linear-gradient(140deg, rgba(255,255,255,0.18), rgba(255,255,255,0) 45%);
+  opacity: 0; pointer-events: none;
+  mix-blend-mode: overlay;
+  transition: opacity .35s ease;
+}
 .wplace-theme-acrylic .script-card::before {
   content: '';
   position: absolute; inset:0;
   background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.15), transparent 60%);
   opacity: 0; pointer-events:none; transition: opacity .4s;
 }
-.wplace-theme-acrylic .script-card:hover { background: var(--sm-card-bg-hover) !important; transform: translateY(-4px); box-shadow: 0 10px 30px rgba(0,0,0,0.45); }
+.wplace-theme-acrylic .script-card:hover { background: var(--sm-card-bg-hover) !important; transform: translateY(-4px); box-shadow: 0 12px 36px -6px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.18); }
 .wplace-theme-acrylic .script-card:hover::before { opacity: 1; }
+.wplace-theme-acrylic .script-card:hover::after { opacity: 1; }
 .wplace-theme-acrylic .script-card:active { transform: translateY(-1px); }
 
 .wplace-theme-acrylic .script-title { color: var(--sm-text) !important; font-weight:600; }

--- a/Extension/script-manager-themes/acrylic.css
+++ b/Extension/script-manager-themes/acrylic.css
@@ -1,0 +1,88 @@
+/* Script Manager Theme: Acrylic (Full Implementation) */
+.sm-theme-acrylic {
+  --sm-primary: rgba(20,20,28,0.55);
+  --sm-secondary: rgba(30,30,40,0.45);
+  --sm-accent: rgba(255,255,255,0.08);
+  --sm-text: #ffffff;
+  --sm-highlight: #7dd3fc;
+  --sm-success: #4ade80;
+  --sm-error: #f87171;
+  --sm-warning: #facc15;
+  --sm-font: 'Inter', system-ui, sans-serif;
+  --sm-border-color: rgba(255,255,255,0.22);
+  --sm-border-width: 1px;
+  --sm-shadow-glow-a: 0 12px 42px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.12);
+  --sm-shadow-glow-b: inset 0 0 42px rgba(255,255,255,0.05);
+  --sm-shadow-outline: 0 0 0 1px rgba(255,255,255,0.18);
+  --sm-card-bg: rgba(255,255,255,0.06);
+  --sm-card-bg-hover: rgba(255,255,255,0.12);
+  --sm-card-border: rgba(255,255,255,0.14);
+  --sm-scrollbar-track: rgba(255,255,255,0.05);
+  --sm-scrollbar-thumb: rgba(255,255,255,0.25);
+  --sm-scrollbar-thumb-hover: rgba(255,255,255,0.38);
+}
+
+.wplace-theme-acrylic .script-manager-container {
+  background: var(--sm-primary) !important;
+  backdrop-filter: blur(18px) saturate(180%) !important;
+  border: var(--sm-border-width) solid var(--sm-border-color) !important;
+  box-shadow: var(--sm-shadow-glow-a), var(--sm-shadow-glow-b) !important;
+  color: var(--sm-text) !important;
+  font-family: var(--sm-font) !important;
+  border-radius: 18px !important;
+}
+
+.wplace-theme-acrylic .script-manager-header {
+  background: linear-gradient(135deg, rgba(255,255,255,0.08), rgba(255,255,255,0.02)) !important;
+  border-bottom: 1px solid rgba(255,255,255,0.12) !important;
+  backdrop-filter: blur(18px) !important;
+}
+.wplace-theme-acrylic .script-manager-title { color: var(--sm-text) !important; font-weight:600; }
+.wplace-theme-acrylic .script-manager-close-btn {
+  background: rgba(255,255,255,0.07) !important;
+  border: 1px solid rgba(255,255,255,0.15) !important;
+  color: var(--sm-highlight) !important;
+  border-radius: 10px !important;
+}
+.wplace-theme-acrylic .script-manager-close-btn:hover { background: rgba(255,255,255,0.15) !important; }
+
+.wplace-theme-acrylic .theme-select-wrapper { background: rgba(255,255,255,0.08) !important; border:1px solid rgba(255,255,255,0.15) !important; }
+.wplace-theme-acrylic select.theme-select { background: rgba(0,0,0,0.35) !important; color: var(--sm-text) !important; border:1px solid rgba(255,255,255,0.2) !important; }
+
+.wplace-theme-acrylic .script-grid { scrollbar-color: var(--sm-scrollbar-thumb) var(--sm-scrollbar-track); }
+.wplace-theme-acrylic .script-card {
+  background: var(--sm-card-bg) !important;
+  border: 1px solid var(--sm-card-border) !important;
+  border-radius: 14px !important;
+  color: var(--sm-text) !important;
+  transition: background .25s, transform .25s, box-shadow .25s;
+  position: relative;
+  overflow: hidden;
+}
+.wplace-theme-acrylic .script-card::before {
+  content: '';
+  position: absolute; inset:0;
+  background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.15), transparent 60%);
+  opacity: 0; pointer-events:none; transition: opacity .4s;
+}
+.wplace-theme-acrylic .script-card:hover { background: var(--sm-card-bg-hover) !important; transform: translateY(-4px); box-shadow: 0 10px 30px rgba(0,0,0,0.45); }
+.wplace-theme-acrylic .script-card:hover::before { opacity: 1; }
+.wplace-theme-acrylic .script-card:active { transform: translateY(-1px); }
+
+.wplace-theme-acrylic .script-title { color: var(--sm-text) !important; font-weight:600; }
+.wplace-theme-acrylic .script-description { color: rgba(255,255,255,0.75) !important; font-size:12px; }
+.wplace-theme-acrylic .script-category {
+  background: rgba(255,255,255,0.08) !important;
+  border: 1px solid rgba(255,255,255,0.15) !important;
+  color: var(--sm-highlight) !important;
+  border-radius: 8px !important;
+  font-size: 11px;
+}
+
+.wplace-theme-acrylic .status-text { color: var(--sm-highlight) !important; font-size: 11px; }
+
+/* Scrollbars */
+.wplace-theme-acrylic .script-grid::-webkit-scrollbar { width: 10px; }
+.wplace-theme-acrylic .script-grid::-webkit-scrollbar-track { background: var(--sm-scrollbar-track); }
+.wplace-theme-acrylic .script-grid::-webkit-scrollbar-thumb { background: var(--sm-scrollbar-thumb); border-radius: 6px; }
+.wplace-theme-acrylic .script-grid::-webkit-scrollbar-thumb:hover { background: var(--sm-scrollbar-thumb-hover); }

--- a/Extension/script-manager-themes/classic-light.css
+++ b/Extension/script-manager-themes/classic-light.css
@@ -1,0 +1,64 @@
+/* Script Manager Theme: Classic Light (Full Implementation) */
+.sm-theme-classic-light {
+  --sm-primary: #ffffff;
+  --sm-secondary: #f8f9fa;
+  --sm-accent: #e9ecef;
+  --sm-text: #212529;
+  --sm-highlight: #6f42c1;
+  --sm-success: #28a745;
+  --sm-error: #dc3545;
+  --sm-warning: #ffc107;
+  --sm-font: 'Segoe UI', Roboto, sans-serif;
+  --sm-border-color: #6f42c1;
+  --sm-border-width: 2px;
+  --sm-shadow-glow-a: 0 8px 32px rgba(0,0,0,0.08), 0 0 0 1px rgba(0,0,0,0.05);
+  --sm-shadow-glow-b: inset 0 0 18px rgba(111,66,193,0.08);
+  --sm-shadow-outline: 0 0 0 1px rgba(111,66,193,0.25);
+  --sm-card-bg: linear-gradient(135deg,#fff,#f8f9fa);
+  --sm-card-bg-hover: linear-gradient(135deg,#f8f9fa,#e9ecef);
+  --sm-card-border: rgba(0,0,0,0.12);
+  --sm-scrollbar-track: rgba(0,0,0,0.06);
+  --sm-scrollbar-thumb: rgba(0,0,0,0.28);
+  --sm-scrollbar-thumb-hover: rgba(0,0,0,0.42);
+}
+
+.wplace-theme-classic-light .script-manager-container {
+  background: linear-gradient(135deg,#fff,#f8f9fa) !important;
+  border: var(--sm-border-width) solid var(--sm-border-color) !important;
+  box-shadow: var(--sm-shadow-glow-a), var(--sm-shadow-glow-b) !important;
+  color: var(--sm-text) !important;
+  font-family: var(--sm-font) !important;
+  border-radius: 16px !important;
+}
+
+.wplace-theme-classic-light .script-manager-header { background: linear-gradient(135deg,#f8f9fa,#e9ecef) !important; border-bottom: 1px solid rgba(0,0,0,0.15) !important; }
+.wplace-theme-classic-light .script-manager-title { color: var(--sm-highlight) !important; font-weight:600; }
+.wplace-theme-classic-light .script-manager-close-btn { background: #e9ecef !important; border:1px solid rgba(0,0,0,0.2) !important; color: var(--sm-highlight) !important; border-radius: 10px !important; }
+.wplace-theme-classic-light .script-manager-close-btn:hover { background: #dee2e6 !important; }
+
+.wplace-theme-classic-light .theme-select-wrapper { background: #f8f9fa !important; border:1px solid rgba(0,0,0,0.15) !important; }
+.wplace-theme-classic-light select.theme-select { background: #fff !important; color: var(--sm-text) !important; border:1px solid rgba(0,0,0,0.2) !important; }
+
+.wplace-theme-classic-light .script-grid { scrollbar-color: var(--sm-scrollbar-thumb) var(--sm-scrollbar-track); }
+.wplace-theme-classic-light .script-card {
+  background: var(--sm-card-bg) !important;
+  border: 1px solid var(--sm-card-border) !important;
+  border-radius: 14px !important;
+  color: var(--sm-text) !important;
+  transition: background .25s, transform .25s, box-shadow .25s;
+  position: relative;
+  overflow: hidden;
+}
+.wplace-theme-classic-light .script-card:hover { background: var(--sm-card-bg-hover) !important; transform: translateY(-3px); box-shadow: 0 8px 24px rgba(0,0,0,0.18); }
+.wplace-theme-classic-light .script-card:active { transform: translateY(-1px); }
+.wplace-theme-classic-light .script-title { color: var(--sm-highlight) !important; font-weight:600; }
+.wplace-theme-classic-light .script-description { color: rgba(33,37,41,0.75) !important; font-size:12px; }
+.wplace-theme-classic-light .script-category { background: rgba(111,66,193,0.12) !important; border:1px solid rgba(111,66,193,0.35) !important; color: var(--sm-highlight) !important; border-radius: 8px !important; font-size:11px; }
+
+.wplace-theme-classic-light .status-text { color: var(--sm-highlight) !important; font-size: 11px; }
+
+/* Scrollbars */
+.wplace-theme-classic-light .script-grid::-webkit-scrollbar { width: 10px; }
+.wplace-theme-classic-light .script-grid::-webkit-scrollbar-track { background: var(--sm-scrollbar-track); }
+.wplace-theme-classic-light .script-grid::-webkit-scrollbar-thumb { background: var(--sm-scrollbar-thumb); border-radius: 6px; }
+.wplace-theme-classic-light .script-grid::-webkit-scrollbar-thumb:hover { background: var(--sm-scrollbar-thumb-hover); }

--- a/Extension/script-manager-themes/classic.css
+++ b/Extension/script-manager-themes/classic.css
@@ -45,7 +45,8 @@
 .wplace-theme-classic .script-manager-close-btn:hover { background: #333 !important; }
 
 .wplace-theme-classic .theme-select-wrapper { background: rgba(255,255,255,0.04) !important; border:1px solid rgba(255,255,255,0.1) !important; }
-.wplace-theme-classic select.theme-select { background: #222 !important; color: var(--sm-text) !important; border:1px solid rgba(255,255,255,0.15) !important; }
+.wplace-theme-classic select.theme-select { background: #111 !important; color: #fafafa !important; border:1px solid rgba(255,255,255,0.28) !important; text-shadow: 0 0 4px rgba(255,255,255,0.35); }
+.wplace-theme-classic select.theme-select option { background:#111 !important; color:#fafafa !important; }
 
 .wplace-theme-classic .script-grid { scrollbar-color: var(--sm-scrollbar-thumb) var(--sm-scrollbar-track); }
 .wplace-theme-classic .script-card {

--- a/Extension/script-manager-themes/classic.css
+++ b/Extension/script-manager-themes/classic.css
@@ -1,0 +1,77 @@
+/* Script Manager Theme: Classic (Full Implementation) */
+.sm-theme-classic {
+  --sm-primary: #121212;
+  --sm-secondary: #1c1c1c;
+  --sm-accent: #222;
+  --sm-text: #ffffff;
+  --sm-highlight: #775ce3;
+  --sm-success: #0f0;
+  --sm-error: #f00;
+  --sm-warning: #fa0;
+  --sm-font: 'Segoe UI', Roboto, sans-serif;
+  --sm-border-color: #775ce3;
+  --sm-border-width: 2px;
+  --sm-shadow-glow-a: 0 8px 40px rgba(79,172,254,0.35), 0 0 0 1px rgba(255,255,255,0.08);
+  --sm-shadow-glow-b: inset 0 0 25px rgba(147,112,219,0.15);
+  --sm-shadow-outline: 0 0 0 1px rgba(147,112,219,0.35);
+  --sm-card-bg: rgba(255,255,255,0.03);
+  --sm-card-bg-hover: rgba(255,255,255,0.07);
+  --sm-card-border: rgba(255,255,255,0.1);
+  --sm-scrollbar-track: rgba(255,255,255,0.05);
+  --sm-scrollbar-thumb: rgba(255,255,255,0.25);
+  --sm-scrollbar-thumb-hover: rgba(255,255,255,0.4);
+}
+
+.wplace-theme-classic .script-manager-container {
+  background: linear-gradient(135deg,#000,#1a1a1a) !important;
+  border: var(--sm-border-width) solid var(--sm-border-color) !important;
+  box-shadow: var(--sm-shadow-glow-a), var(--sm-shadow-glow-b) !important;
+  color: var(--sm-text) !important;
+  font-family: var(--sm-font) !important;
+  border-radius: 16px !important;
+}
+
+.wplace-theme-classic .script-manager-header {
+  background: linear-gradient(135deg,#111,#2a2a2a) !important;
+  border-bottom: 1px solid rgba(255,255,255,0.1) !important;
+}
+.wplace-theme-classic .script-manager-title { color: var(--sm-highlight) !important; font-weight:600; }
+.wplace-theme-classic .script-manager-close-btn {
+  background: #222 !important;
+  border: 1px solid rgba(255,255,255,0.15) !important;
+  color: var(--sm-highlight) !important;
+  border-radius: 10px !important;
+}
+.wplace-theme-classic .script-manager-close-btn:hover { background: #333 !important; }
+
+.wplace-theme-classic .theme-select-wrapper { background: rgba(255,255,255,0.04) !important; border:1px solid rgba(255,255,255,0.1) !important; }
+.wplace-theme-classic select.theme-select { background: #222 !important; color: var(--sm-text) !important; border:1px solid rgba(255,255,255,0.15) !important; }
+
+.wplace-theme-classic .script-grid { scrollbar-color: var(--sm-scrollbar-thumb) var(--sm-scrollbar-track); }
+.wplace-theme-classic .script-card {
+  background: var(--sm-card-bg) !important;
+  border: 1px solid var(--sm-card-border) !important;
+  border-radius: 14px !important;
+  color: var(--sm-text) !important;
+  transition: background .25s, transform .25s, box-shadow .25s;
+  position: relative;
+}
+.wplace-theme-classic .script-card:hover { background: var(--sm-card-bg-hover) !important; transform: translateY(-3px); box-shadow: 0 6px 20px rgba(0,0,0,0.55); }
+.wplace-theme-classic .script-card:active { transform: translateY(-1px); }
+.wplace-theme-classic .script-title { color: var(--sm-highlight) !important; font-weight:600; }
+.wplace-theme-classic .script-description { color: rgba(255,255,255,0.75) !important; font-size:12px; }
+.wplace-theme-classic .script-category {
+  background: rgba(119,92,227,0.12) !important;
+  border: 1px solid rgba(119,92,227,0.35) !important;
+  color: var(--sm-highlight) !important;
+  border-radius: 8px !important;
+  font-size: 11px;
+}
+
+.wplace-theme-classic .status-text { color: var(--sm-highlight) !important; font-size: 11px; }
+
+/* Scrollbars */
+.wplace-theme-classic .script-grid::-webkit-scrollbar { width: 10px; }
+.wplace-theme-classic .script-grid::-webkit-scrollbar-track { background: var(--sm-scrollbar-track); }
+.wplace-theme-classic .script-grid::-webkit-scrollbar-thumb { background: var(--sm-scrollbar-thumb); border-radius: 6px; }
+.wplace-theme-classic .script-grid::-webkit-scrollbar-thumb:hover { background: var(--sm-scrollbar-thumb-hover); }

--- a/Extension/script-manager-themes/neon.css
+++ b/Extension/script-manager-themes/neon.css
@@ -1,0 +1,124 @@
+/* Script Manager Theme: Neon (Full Implementation) */
+:root, .sm-theme-neon {
+  --sm-primary: #1a1a2e;
+  --sm-secondary: #16213e;
+  --sm-accent: #0f3460;
+  --sm-text: #00ff41;
+  --sm-highlight: #ff6b35;
+  --sm-success: #39ff14;
+  --sm-error: #ff073a;
+  --sm-warning: #ff0;
+  --sm-font: 'Press Start 2P', monospace, 'Courier New';
+  --sm-border-color: #00ff41;
+  --sm-border-width: 3px;
+  --sm-shadow-glow-a: 0 0 30px rgb(0 255 65 / 50%);
+  --sm-shadow-glow-b: inset 0 0 30px rgb(0 255 65 / 10%);
+  --sm-shadow-outline: 0 0 0 1px #00ff41;
+  --sm-card-bg: rgb(0 255 65 / 8%);
+  --sm-card-border: rgb(0 255 65 / 40%);
+  --sm-card-hover: rgb(0 255 65 / 18%);
+  --sm-scrollbar-track: rgb(0 255 65 / 10%);
+  --sm-scrollbar-thumb: #00ff41;
+  --sm-scrollbar-thumb-hover: #39ff14;
+}
+
+/* Container */
+.wplace-theme-neon .script-manager-container {
+  background: var(--sm-primary) !important;
+  border: var(--sm-border-width) solid var(--sm-border-color) !important;
+  box-shadow: var(--sm-shadow-glow-a), var(--sm-shadow-glow-b) !important;
+  color: var(--sm-text) !important;
+  font-family: var(--sm-font) !important;
+  text-shadow: 0 0 6px var(--sm-text) !important;
+  border-radius: 0 !important;
+  position: relative;
+  overflow: hidden;
+}
+
+/* Header */
+.wplace-theme-neon .script-manager-header {
+  background: var(--sm-secondary) !important;
+  border-bottom: 1px solid var(--sm-border-color) !important;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-size: 11px;
+}
+.wplace-theme-neon .script-manager-title { color: var(--sm-text) !important; text-shadow: 0 0 10px var(--sm-text) !important; }
+.wplace-theme-neon .script-manager-close-btn {
+  background: var(--sm-secondary) !important;
+  color: var(--sm-text) !important;
+  border: 1px solid var(--sm-border-color) !important;
+  font-family: var(--sm-font) !important;
+  border-radius: 0 !important;
+}
+.wplace-theme-neon .script-manager-close-btn:hover { background: var(--sm-error) !important; text-shadow: 0 0 8px var(--sm-error); }
+
+/* Theme selector */
+.wplace-theme-neon .theme-select-wrapper { background: var(--sm-secondary) !important; border:1px solid var(--sm-border-color) !important; }
+.wplace-theme-neon select.theme-select {
+  background: var(--sm-secondary) !important;
+  color: var(--sm-text) !important;
+  border: 1px solid var(--sm-border-color) !important;
+  text-shadow: 0 0 5px var(--sm-text) !important;
+  font-family: var(--sm-font) !important;
+  font-size: 10px !important;
+  border-radius: 0 !important;
+}
+
+/* Script grid / cards */
+.wplace-theme-neon .script-grid { scrollbar-color: var(--sm-scrollbar-thumb) var(--sm-scrollbar-track); }
+.wplace-theme-neon .script-card {
+  background: var(--sm-card-bg) !important;
+  border: 1px solid var(--sm-card-border) !important;
+  border-radius: 0 !important;
+  color: var(--sm-text) !important;
+  font-family: var(--sm-font) !important;
+  transition: background .2s, box-shadow .2s, transform .2s;
+  position: relative;
+}
+.wplace-theme-neon .script-card:hover {
+  background: var(--sm-card-hover) !important;
+  box-shadow: 0 0 18px var(--sm-text), inset 0 0 20px rgb(0 255 65 / 15%) !important;
+  transform: translateY(-2px);
+}
+.wplace-theme-neon .script-card:active { transform: translateY(0); }
+
+.wplace-theme-neon .script-card-header .script-icon { text-shadow: 0 0 12px var(--sm-text); }
+.wplace-theme-neon .script-title { color: var(--sm-text) !important; text-shadow: 0 0 6px var(--sm-text) !important; font-size: 11px; }
+.wplace-theme-neon .script-description { color: var(--sm-text); opacity: .85; font-size: 9px; text-shadow: 0 0 4px var(--sm-text); }
+.wplace-theme-neon .script-category {
+  background: var(--sm-secondary) !important;
+  border: 1px solid var(--sm-border-color) !important;
+  color: var(--sm-highlight) !important;
+  text-shadow: 0 0 6px var(--sm-highlight) !important;
+  font-family: var(--sm-font) !important;
+  border-radius: 0 !important;
+}
+
+/* Status text */
+.wplace-theme-neon .status-text { color: var(--sm-text) !important; text-shadow: 0 0 10px var(--sm-text) !important; font-family: var(--sm-font) !important; font-size:10px; }
+
+/* Scrollbars (WebKit) */
+.wplace-theme-neon .script-grid::-webkit-scrollbar { width: 10px; }
+.wplace-theme-neon .script-grid::-webkit-scrollbar-track { background: var(--sm-scrollbar-track); }
+.wplace-theme-neon .script-grid::-webkit-scrollbar-thumb { background: var(--sm-scrollbar-thumb); box-shadow: 0 0 10px var(--sm-text); }
+.wplace-theme-neon .script-grid::-webkit-scrollbar-thumb:hover { background: var(--sm-scrollbar-thumb-hover); }
+
+/* Scanline overlay (optional) */
+.wplace-theme-neon .script-manager-container::before {
+  content: '';
+  position: absolute; inset:0;
+  background: repeating-linear-gradient(180deg, rgba(0,255,65,0.08) 0 1px, transparent 1px 3px);
+  mix-blend-mode: lighten;
+  pointer-events: none;
+  animation: sm-neon-scan 6s linear infinite;
+  opacity: .4;
+}
+
+@keyframes sm-neon-scan { 0% { transform: translateY(-50%);} 100% { transform: translateY(50%);} }
+
+/* Glow pulse */
+@media (prefers-reduced-motion: no-preference) {
+  .wplace-theme-neon .script-manager-container { animation: sm-neon-pulse 3s ease-in-out infinite alternate; }
+  @keyframes sm-neon-pulse { 0% { box-shadow: var(--sm-shadow-glow-a), var(--sm-shadow-glow-b);} 100% { box-shadow: 0 0 40px rgb(0 255 65 / 70%), inset 0 0 35px rgb(0 255 65 / 18%);} }
+}

--- a/Extension/script-manager-themes/theme-template.css
+++ b/Extension/script-manager-themes/theme-template.css
@@ -1,0 +1,189 @@
+/* =============================================================
+   WPlace AutoBOT Script Manager Theme Template
+   -------------------------------------------------------------
+   Copy this file to create a new theme:
+   1. Duplicate and rename: themes/<your-theme>.css
+   2. Replace THEME-NAME with your descriptive theme slug
+   3. Adjust variables ONLY inside the variable block first
+   4. Tweak component overrides below if necessary
+   5. Add script‑manager glow overrides for cohesive UI
+
+   Variable naming conventions:
+     --wplace-*   : Core UI variables consumed by scripts/components
+     --sm-*       : Script Manager specific overrides (glow, borders)
+
+   Keep themes focused: prefer changing variables over deep selectors.
+   ============================================================= */
+
+/* === CORE THEME VARIABLES ==================================== */
+.wplace-theme-THEME-NAME {
+  /* Base palette */
+  --wplace-primary:            #121418;                 /* Main panel background (can be gradient) */
+  --wplace-secondary:          #1c2026;                 /* Headers / secondary panels */
+  --wplace-accent:             #252b33;                 /* Accents / separators */
+  --wplace-text:               #f5f7fa;                 /* Primary text */
+  --wplace-highlight:          #6d8bff;                 /* Accent highlight color */
+  --wplace-success:            #40d673;                 /* Success color */
+  --wplace-error:              #ff4f5e;                 /* Error color */
+  --wplace-warning:            #ffcc47;                 /* Warning color */
+
+  /* Radii / shapes */
+  --wplace-radius:             14px;                    /* General corner radius */
+  --wplace-btn-radius:         18px;                    /* Buttons */
+
+  /* Border styling */
+  --wplace-border-style:       solid; 
+  --wplace-border-width:       1px;                     /* Outer container borders */
+  --wplace-border-color:       rgba(255,255,255,0.12);
+
+  /* Shadow & backdrop */
+  --wplace-shadow:             0 6px 28px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.05);
+  --wplace-backdrop:           blur(14px) saturate(150%);
+
+  /* Typography */
+  --wplace-font:               'Inter', system-ui, sans-serif;
+
+  /* Feature toggles */
+  --wplace-scanline:           0;                        /* 1 enables scanline effect */
+  --wplace-pixel-blink:        0;                        /* 1 enables retro blink */
+
+  /* Extended semantic colors (optional) */
+  --wplace-danger:             var(--wplace-error);
+  --wplace-danger-dark:        #d83c49;
+  --wplace-muted-text:         rgba(245,247,250,0.55);
+  --wplace-highlight-secondary:#9cb6ff;
+
+  /* Text hierarchy */
+  --wplace-text-secondary:     rgba(245,247,250,0.85);
+  --wplace-text-muted:         rgba(245,247,250,0.65);
+  --wplace-text-dim:           rgba(245,247,250,0.5);
+  --wplace-text-faded:         rgba(245,247,250,0.75);
+
+  /* Background nuance */
+  --wplace-bg-input:           rgba(255,255,255,0.06);
+  --wplace-bg-subtle:          rgba(255,255,255,0.04);
+  --wplace-bg-faint:           rgba(255,255,255,0.03);
+  --wplace-bg-ghost:           rgba(255,255,255,0.02);
+  --wplace-bg-whisper:         rgba(255,255,255,0.01);
+
+  /* Border nuance */
+  --wplace-border-subtle:      rgba(255,255,255,0.18);
+  --wplace-border-faint:       rgba(255,255,255,0.12);
+  --wplace-border-ghost:       rgba(255,255,255,0.08);
+  --wplace-border-ultra-faint: rgba(255,255,255,0.05);
+
+  /* Shadows (component specific) */
+  --wplace-shadow-drag:        0 12px 44px rgba(0,0,0,0.55), 0 0 0 1px rgba(109,139,255,0.35);
+  --wplace-shadow-notification:0 4px 14px rgba(0,0,0,0.5);
+  --wplace-shadow-slider-thumb:0 3px 6px rgba(0,0,0,0.6), 0 0 0 2px var(--wplace-highlight);
+  --wplace-shadow-slider-hover:0 4px 10px rgba(0,0,0,0.65), 0 0 0 3px var(--wplace-highlight);
+
+  /* Slider colors */
+  --wplace-slider-thumb-bg:    var(--wplace-highlight);
+  --wplace-slider-track-bg:    linear-gradient(90deg,#6d8bff 0%,#9cb6ff 100%);
+
+  /* Pulse animation colors */
+  --wplace-pulse-start:        rgba(109,139,255,0.75);
+  --wplace-pulse-mid:          rgba(109,139,255,0.0);
+  --wplace-pulse-end:          rgba(109,139,255,0.0);
+
+  /* Script Manager glow overrides */
+  --sm-shadow-glow-a:          0 8px 40px rgba(109,139,255,0.35), 0 0 0 1px rgba(255,255,255,0.06);
+  --sm-shadow-glow-b:          inset 0 0 28px rgba(109,139,255,0.18);
+  --sm-shadow-outline:         0 0 0 1px rgba(109,139,255,0.45);
+  --sm-border-color:           #6d8bff;
+  --sm-border-width:           2px;
+}
+
+/* === CORE CONTAINERS (prefer variables over hard-coded) ====== */
+.wplace-theme-THEME-NAME #wplace-image-bot-container,
+.wplace-theme-THEME-NAME #wplace-settings-container,
+.wplace-theme-THEME-NAME #wplace-stats-container {
+  background: var(--wplace-primary) !important;
+  color: var(--wplace-text) !important;
+  border-radius: var(--wplace-radius) !important;
+  box-shadow: var(--wplace-shadow) !important;
+  backdrop-filter: var(--wplace-backdrop) !important;
+  border: var(--wplace-border-width) var(--wplace-border-style) var(--wplace-border-color) !important;
+  font-family: var(--wplace-font) !important;
+}
+
+/* Headers */
+.wplace-theme-THEME-NAME .wplace-header {
+  background: var(--wplace-secondary) !important;
+  color: var(--wplace-highlight) !important;
+  font-family: var(--wplace-font) !important;
+  border-bottom: 1px solid var(--wplace-border-subtle) !important;
+}
+
+/* Sections */
+.wplace-theme-THEME-NAME .wplace-section,
+.wplace-theme-THEME-NAME .wplace-status-section,
+.wplace-theme-THEME-NAME .wplace-settings-section-wrapper {
+  background: var(--wplace-bg-subtle) !important;
+  border: 1px solid var(--wplace-border-faint) !important;
+  border-radius: var(--wplace-radius) !important;
+}
+
+/* Buttons */
+.wplace-theme-THEME-NAME .wplace-btn {
+  background: linear-gradient(135deg, var(--wplace-accent) 0%, var(--wplace-secondary) 100%) !important;
+  color: var(--wplace-text) !important;
+  border-radius: var(--wplace-btn-radius) !important;
+  border: 1px solid var(--wplace-border-faint) !important;
+  font-family: var(--wplace-font) !important;
+}
+.wplace-theme-THEME-NAME .wplace-btn:hover:not(:disabled) {
+  box-shadow: 0 4px 14px rgba(0,0,0,0.5), 0 0 0 1px var(--wplace-highlight) !important;
+}
+.wplace-theme-THEME-NAME .wplace-btn-start { background: linear-gradient(135deg,var(--wplace-success) 0%,#208a48 100%) !important; }
+.wplace-theme-THEME-NAME .wplace-btn-stop  { background: linear-gradient(135deg,var(--wplace-error) 0%,#b8303c 100%) !important; }
+.wplace-theme-THEME-NAME .wplace-btn-select{ background: linear-gradient(135deg,var(--wplace-highlight) 0%,#445dba 100%) !important; }
+.wplace-theme-THEME-NAME .wplace-btn-file  { background: linear-gradient(135deg,var(--wplace-warning) 0%,#c79600 100%) !important; }
+
+/* Progress */
+.wplace-theme-THEME-NAME .wplace-progress {
+  background: var(--wplace-bg-faint) !important;
+  border: 1px solid var(--wplace-border-faint) !important;
+  border-radius: var(--wplace-radius) !important;
+}
+.wplace-theme-THEME-NAME .wplace-progress-bar {
+  background: linear-gradient(90deg,var(--wplace-success) 0%, var(--wplace-highlight) 100%) !important;
+  box-shadow: 0 0 10px var(--wplace-success) !important;
+}
+
+/* Status badges */
+.wplace-theme-THEME-NAME .status-success { background: rgba(64,214,115,0.12) !important; color: var(--wplace-success) !important; }
+.wplace-theme-THEME-NAME .status-error   { background: rgba(255,79,94,0.15) !important; color: var(--wplace-error) !important; }
+.wplace-theme-THEME-NAME .status-default { background: var(--wplace-bg-input) !important; color: var(--wplace-text) !important; }
+
+/* Sliders */
+.wplace-theme-THEME-NAME .wplace-slider,
+.wplace-theme-THEME-NAME .wplace-speed-slider,
+.wplace-theme-THEME-NAME .wplace-overlay-opacity-slider {
+  background: var(--wplace-bg-input) !important;
+  border: 1px solid var(--wplace-border-faint) !important;
+  border-radius: 6px !important;
+}
+.wplace-theme-THEME-NAME .wplace-slider::-webkit-slider-thumb,
+.wplace-theme-THEME-NAME .wplace-speed-slider::-webkit-slider-thumb,
+.wplace-theme-THEME-NAME .wplace-overlay-opacity-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px; height: 16px;
+  background: var(--wplace-slider-thumb-bg);
+  border: 2px solid var(--wplace-highlight);
+  border-radius: 50%;
+  box-shadow: var(--wplace-shadow-slider-thumb);
+  cursor: pointer;
+}
+
+/* Script Manager OPTIONAL extra accent (only if desired) */
+.wplace-theme-THEME-NAME .script-manager-container { backdrop-filter: var(--wplace-backdrop); }
+
+/* === OPTIONAL ANIMATIONS ===================================== */
+@media (prefers-reduced-motion: no-preference) {
+  .wplace-theme-THEME-NAME .wplace-btn:active { transform: translateY(1px); }
+}
+
+/* === END THEME TEMPLATE ====================================== */


### PR DESCRIPTION
Adds dedicated manager theme layer injection (autobot-manager-theme) so Script Manager themes (classic, acrylic, etc.) properly override base themes. Ensures dynamic selection loads matching manager CSS after base layer. Removed redundant inline comments for clarity.

Changes:

Added applyManagerThemeLayer() and integrated into applyAutobotTheme()
Injects manager CSS if available; falls back gracefully
Removed non-essential descriptive comments