### PR TITLE
Improvements for large images handling

### DIFF
--- a/Extension/scripts/Auto-Image.js
+++ b/Extension/scripts/Auto-Image.js
@@ -8736,21 +8736,9 @@ function getText(key, params) {
 
     // Paint pixels until we run out of charges or complete the image
     try {
-      // First generate coordinates without filtering to count skipped ones
-      const allCoords = generateCoordinates(
-        width,
-        height,
-        state.coordinateMode,
-        state.coordinateDirection,
-        state.coordinateSnake,
-        state.blockWidth,
-        state.blockHeight,
-        0, // Don't filter here
-        0  // Don't filter here
-      );
 
       // Generate the actual filtered coordinates for painting (resuming from last position)
-      const coords = generateCoordinates(
+      const coords = await generateCoordinatesAsync(
         width,
         height,
         state.coordinateMode,
@@ -10612,3 +10600,250 @@ function getText(key, params) {
     });
   });
 })();
+
+// === Async coordinate generation (off-main-thread) ===
+async function generateCoordinatesAsync(
+  width,
+  height,
+  mode,
+  direction,
+  snake,
+  blockWidth,
+  blockHeight,
+  startFromX = 0,
+  startFromY = 0
+) {
+  try {
+    if (typeof Worker === 'undefined') {
+      // Environment does not support Web Workers – fall back
+      return generateCoordinates(
+        width,
+        height,
+        mode,
+        direction,
+        snake,
+        blockWidth,
+        blockHeight,
+        startFromX,
+        startFromY
+      );
+    }
+
+    const workerCode = `self.onmessage = function(e) {
+  const { width, height, mode, direction, snake, blockWidth, blockHeight, startFromX, startFromY } = e.data || {};
+
+  function generate() {
+    let coords = [];
+
+    // Determine traversal direction
+    let xStart, xEnd, xStep;
+    let yStart, yEnd, yStep;
+    switch (direction) {
+      case 'top-left':
+        xStart = 0; xEnd = width; xStep = 1;
+        yStart = 0; yEnd = height; yStep = 1;
+        break;
+      case 'top-right':
+        xStart = width - 1; xEnd = -1; xStep = -1;
+        yStart = 0; yEnd = height; yStep = 1;
+        break;
+      case 'bottom-left':
+        xStart = 0; xEnd = width; xStep = 1;
+        yStart = height - 1; yEnd = -1; yStep = -1;
+        break;
+      case 'bottom-right':
+        xStart = width - 1; xEnd = -1; xStep = -1;
+        yStart = height - 1; yEnd = -1; yStep = -1;
+        break;
+      default:
+        throw new Error('Unknown direction: ' + direction);
+    }
+
+    if (mode === 'rows') {
+      let rowIndex = 0;
+      for (let y = yStart; y !== yEnd; y += yStep) {
+        if (snake && rowIndex % 2 !== 0) {
+          for (let x = xEnd - xStep; x !== xStart - xStep; x -= xStep) {
+            coords.push([x, y]);
+          }
+        } else {
+          for (let x = xStart; x !== xEnd; x += xStep) {
+            coords.push([x, y]);
+          }
+        }
+        rowIndex++;
+      }
+    } else if (mode === 'columns') {
+      let colIndex = 0;
+      for (let x = xStart; x !== xEnd; x += xStep) {
+        if (snake && colIndex % 2 !== 0) {
+          for (let y = yEnd - yStep; y !== yStart - yStep; y -= yStep) {
+            coords.push([x, y]);
+          }
+        } else {
+          for (let y = yStart; y !== yEnd; y += yStep) {
+            coords.push([x, y]);
+          }
+        }
+        colIndex++;
+      }
+    } else if (mode === 'circle-out') {
+      const cx = Math.floor(width / 2);
+      const cy = Math.floor(height / 2);
+      const maxRadius = Math.ceil(Math.sqrt(cx * cx + cy * cy));
+      for (let r = 0; r <= maxRadius; r++) {
+        for (let y = cy - r; y <= cy + r; y++) {
+          for (let x = cx - r; x <= cx + r; x++) {
+            if (x >= 0 && x < width && y >= 0 && y < height) {
+              const dist = Math.max(Math.abs(x - cx), Math.abs(y - cy));
+              if (dist === r) coords.push([x, y]);
+            }
+          }
+        }
+      }
+    } else if (mode === 'circle-in') {
+      const cx = Math.floor(width / 2);
+      const cy = Math.floor(height / 2);
+      const maxRadius = Math.ceil(Math.sqrt(cx * cx + cy * cy));
+      for (let r = maxRadius; r >= 0; r--) {
+        for (let y = cy - r; y <= cy + r; y++) {
+          for (let x = cx - r; x <= cx + r; x++) {
+            if (x >= 0 && x < width && y >= 0 && y < height) {
+              const dist = Math.max(Math.abs(x - cx), Math.abs(y - cy));
+              if (dist === r) coords.push([x, y]);
+            }
+          }
+        }
+      }
+    } else if (mode === 'blocks' || mode === 'shuffle-blocks') {
+      const blocks = [];
+      for (let by = 0; by < height; by += blockHeight) {
+        for (let bx = 0; bx < width; bx += blockWidth) {
+          const block = [];
+          for (let y = by; y < Math.min(by + blockHeight, height); y++) {
+            for (let x = bx; x < Math.min(bx + blockWidth, width); x++) {
+              block.push([x, y]);
+            }
+          }
+          blocks.push(block);
+        }
+      }
+      if (mode === 'shuffle-blocks') {
+        for (let i = blocks.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          const tmp = blocks[i];
+          blocks[i] = blocks[j];
+          blocks[j] = tmp;
+        }
+      }
+      for (const block of blocks) {
+        coords = coords.concat(block); // avoid spread on huge arrays
+      }
+    } else {
+      throw new Error('Unknown mode: ' + mode);
+    }
+
+    // Resume from specified position if provided
+    if (startFromX > 0 || startFromY > 0) {
+      let startIndex = -1;
+      for (let i = 0; i < coords.length; i++) {
+        const c = coords[i];
+        if (c[0] === startFromX && c[1] === startFromY) {
+          startIndex = i;
+          break;
+        }
+      }
+      if (startIndex >= 0) {
+        coords = coords.slice(startIndex);
+      }
+    }
+
+    return coords;
+  }
+
+  try {
+    const coords = generate();
+    self.postMessage({ ok: true, coords });
+  } catch (err) {
+    self.postMessage({ ok: false, error: err && (err.message || String(err)) });
+  }
+};`;
+
+    const blob = new Blob([workerCode], { type: 'application/javascript' });
+    const url = URL.createObjectURL(blob);
+
+    return await new Promise((resolve) => {
+      const worker = new Worker(url);
+      const cleanup = () => {
+        URL.revokeObjectURL(url);
+        try { worker.terminate(); } catch (e) { }
+      };
+
+      worker.onmessage = (e) => {
+        const { ok, coords, error } = e.data || {};
+        cleanup();
+        if (ok && Array.isArray(coords)) {
+          resolve(coords);
+        } else {
+          console.warn('Coordinate worker failed, falling back to sync:', error);
+          resolve(
+            generateCoordinates(
+              width,
+              height,
+              mode,
+              direction,
+              snake,
+              blockWidth,
+              blockHeight,
+              startFromX,
+              startFromY
+            )
+          );
+        }
+      };
+
+      worker.onerror = (err) => {
+        console.warn('Coordinate worker error, falling back to sync:', err && (err.message || err));
+        cleanup();
+        resolve(
+          generateCoordinates(
+            width,
+            height,
+            mode,
+            direction,
+            snake,
+            blockWidth,
+            blockHeight,
+            startFromX,
+            startFromY
+          )
+        );
+      };
+
+      worker.postMessage({
+        width,
+        height,
+        mode,
+        direction,
+        snake,
+        blockWidth,
+        blockHeight,
+        startFromX,
+        startFromY,
+      });
+    });
+  } catch (e) {
+    console.warn('Failed to start coordinate worker, using sync generation:', e);
+    return generateCoordinates(
+      width,
+      height,
+      mode,
+      direction,
+      snake,
+      blockWidth,
+      blockHeight,
+      startFromX,
+      startFromY
+    );
+  }
+}

--- a/Extension/scripts/utils-manager.js
+++ b/Extension/scripts/utils-manager.js
@@ -673,7 +673,7 @@ class WPlaceUtilsManager {
   }
 
   buildProgressData() {
-    return {
+    const result = {
       timestamp: Date.now(),
       version: '2.2',
       state: {
@@ -691,16 +691,42 @@ class WPlaceUtilsManager {
         blockHeight: window.state.blockHeight,
         availableColors: window.state.availableColors,
       },
-      imageData: window.state.imageData
-        ? {
-          width: window.state.imageData.width,
-          height: window.state.imageData.height,
-          pixels: Array.from(window.state.imageData.pixels),
-          totalPixels: window.state.imageData.totalPixels,
-        }
-        : null,
-      paintedMapPacked: this.buildPaintedMapPacked(),
+      imageData: null,
+      paintedMapPacked: null,
     };
+
+    // Decide how to store image pixels
+    if (window.state.imageData) {
+      const img = window.state.imageData;
+      const width = img.width;
+      const height = img.height;
+      const totalPixels = img.totalPixels;
+      const pixels = img.pixels;
+
+      const USE_IDB_THRESHOLD = 500000; // ~0.5 MB raw RGBA (before JSON expansion)
+
+      if (pixels && pixels.length) {
+        const bytes = pixels.length; // Uint8ClampedArray length equals byte size
+        if (bytes > USE_IDB_THRESHOLD) {
+          // Store pixels in IndexedDB and keep only the reference in save payload
+          const ref = this.generatePixelsRef(width, height);
+          try {
+            // Fire-and-forget async persist
+            this.storePixelsInIndexedDB(ref, { width, height, totalPixels, pixels });
+          } catch (e) {
+            console.warn('Failed to schedule IDB pixel store:', e);
+          }
+          result.imageData = { width, height, totalPixels, pixelsRef: ref, pixelsBackend: 'idb' };
+        } else {
+          result.imageData = { width, height, pixels: Array.from(pixels), totalPixels };
+        }
+      } else {
+        result.imageData = { width, height, totalPixels, pixels: null };
+      }
+    }
+
+    result.paintedMapPacked = this.buildPaintedMapPacked();
+    return result;
   }
 
   migrateProgress(saved) {
@@ -865,6 +891,45 @@ class WPlaceUtilsManager {
         } catch (e) {
           console.warn('Could not rebuild processor from saved image data:', e);
         }
+      } else if (savedData.imageData && savedData.imageData.pixelsRef) {
+        // Asynchronously load large pixel data from IndexedDB using the stored reference
+        console.log('🔄 Loading large image pixels from IndexedDB via ref:', savedData.imageData.pixelsRef);
+        window.state.imageData = {
+          width: savedData.imageData.width,
+          height: savedData.imageData.height,
+          totalPixels: savedData.imageData.totalPixels,
+          pixels: null,
+        };
+        window.state.imageLoaded = false;
+
+        this.loadPixelsFromIndexedDB(savedData.imageData.pixelsRef)
+          .then((payload) => {
+            if (!payload || !payload.pixels) {
+              console.warn('⚠️ No pixel payload found in IndexedDB for ref:', savedData.imageData.pixelsRef);
+              this.showAlert?.('⚠️ Saved image pixels not found in local database. Please reload the image file.', 'warning');
+              return;
+            }
+            try {
+              window.state.imageData.pixels = payload.pixels instanceof Uint8Array || payload.pixels instanceof Uint8ClampedArray
+                ? new Uint8ClampedArray(payload.pixels)
+                : new Uint8ClampedArray(payload.pixels);
+              window.state.imageLoaded = true;
+
+              // Rebuild processor and notify modules/UI
+              this._syncModulesAfterStateRestore();
+              this.showAlert?.('✅ Large image restored from local database.', 'success');
+
+              // Attempt overlay restoration if available
+              if (typeof this.restoreOverlayFromData === 'function') {
+                this.restoreOverlayFromData().catch(() => {});
+              }
+            } catch (err) {
+              console.warn('Failed to apply pixels from IndexedDB:', err);
+            }
+          })
+          .catch((err) => {
+            console.warn('Failed to load pixels from IndexedDB:', err);
+          });
       } else if (savedData.imageData && savedData.imageData.pixelsStripped) {
         console.warn('⚠️ Saved progress did not include raw pixel data due to quota limits. Please reload the image to resume.');
         window.state.imageData = {
@@ -1294,3 +1359,70 @@ if (!window.globalUtilsManager) {
     }
   }, 100);
 }
+
+// === IndexedDB helpers for large pixel storage ===
+WPlaceUtilsManager.prototype._openPixelDB = function() {
+  return new Promise((resolve, reject) => {
+    try {
+      const request = indexedDB.open('wplace-bot-db', 1);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains('pixels')) {
+          const store = db.createObjectStore('pixels', { keyPath: 'ref' });
+          try { store.createIndex('createdAt', 'createdAt', { unique: false }); } catch {}
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    } catch (e) {
+      reject(e);
+    }
+  });
+};
+
+WPlaceUtilsManager.prototype.generatePixelsRef = function(width, height) {
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `img_${width}x${height}_${Date.now().toString(36)}_${rand}`;
+};
+
+WPlaceUtilsManager.prototype.storePixelsInIndexedDB = async function(ref, payload) {
+  try {
+    const db = await this._openPixelDB();
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction('pixels', 'readwrite');
+      const store = tx.objectStore('pixels');
+      const data = {
+        ref,
+        width: payload.width,
+        height: payload.height,
+        totalPixels: payload.totalPixels,
+        pixels: payload.pixels instanceof Uint8Array || payload.pixels instanceof Uint8ClampedArray
+          ? new Uint8Array(payload.pixels)
+          : new Uint8Array(payload.pixels),
+        createdAt: Date.now(),
+      };
+      const req = store.put(data);
+      req.onsuccess = () => resolve(true);
+      req.onerror = () => reject(req.error);
+    });
+  } catch (e) {
+    console.warn('IDB storePixels failed:', e);
+    return false;
+  }
+};
+
+WPlaceUtilsManager.prototype.loadPixelsFromIndexedDB = async function(ref) {
+  try {
+    const db = await this._openPixelDB();
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction('pixels', 'readonly');
+      const store = tx.objectStore('pixels');
+      const req = store.get(ref);
+      req.onsuccess = () => resolve(req.result || null);
+      req.onerror = () => reject(req.error);
+    });
+  } catch (e) {
+    console.warn('IDB loadPixels failed:', e);
+    return null;
+  }
+};


### PR DESCRIPTION
Before I can't paint a very large images due to browser storage limits. 

<img width="830" height="182" alt="image" src="https://github.com/user-attachments/assets/5d41e147-9a6a-4d22-9855-ccd69f54531b" />

Add IndexedDB fallback in case of limits.

Removed unnecessary long calculations of pixels and moved the rest to the worker to avoid a long freeze when calculationg.